### PR TITLE
fix: update GitHub Actions workflow to use npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,4 +28,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm run publish
+        run: npm publish


### PR DESCRIPTION
- Changed the workflow command from 'npm run publish' to 'npm publish' for consistency and clarity in the release process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow configuration for package publishing process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->